### PR TITLE
A suggestion in Lab 12

### DIFF
--- a/Labs/Lab 12/README.md
+++ b/Labs/Lab 12/README.md
@@ -1,7 +1,7 @@
 # Lab 12 - Configuring CI/CD Pipelines as Code with YAML in Azure DevOps
 
 1. Configuring CI/CD Pipelines as Code with YAML in Azure DevOps
-2. reating Azure resources
+2. Creating Azure resources
 3. Configuring the Parts Unlimited project
 4. Adding a YAML build definition
 5. Adding continuous delivery to the YAML definition
@@ -10,7 +10,7 @@
 ### Lifelines:
 
 * Step-by-Step Instructions:
-[Deploying a Docker Web Application to Azure App Service](https://azuredevopslabs.com/labs/vstsextend/docker/)
+[Configuring CI/CD Pipelines as Code with YAML in Azure DevOps](https://azuredevopslabs.com/labs/azuredevops/yaml/)
 
 ### Navigation:
 


### PR DESCRIPTION
Hi Mike,

I notice the Step-by-Step Instructions reference link in Lab 12 and Lab 13 are the same. So I send you a correction

Thanks for making this repository is helping me a lot.

----------------------------
docs: Update README.md

The Step-by-Step Instructions web reference was renamed and changed to the correct link
[Configuring CI/CD Pipelines as Code with YAML in Azure DevOps](https://azuredevopslabs.com/labs/azuredevops/yaml/)

Additionally, I added some missing letters in the task list